### PR TITLE
Fix an error, that occurs when call the gianism_is_user_connected_with

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -145,7 +145,7 @@ function gianism_is_user_connected_with( $service, $user_id = 0 ) {
 		$user_id = get_current_user_id();
 	}
 
-	return ( $instance = $gianism->get_service_instance( $service ) ) && $instance->is_connected( $user_id );
+	return ( $instance = $gianism->service->get( $service ) ) && $instance->is_connected( $user_id );
 }
 
 
@@ -166,7 +166,7 @@ function gianism_is_user_connected_with( $service, $user_id = 0 ) {
 function gianism_get_user_by_service( $service, $credential ) {
 	global $wpdb;
 	$gianism  = \Gianism\Bootstrap::get_instance();
-	$instance = $gianism->get_instance( $service );
+	$instance = $gianism->service->get( $service );
 	if ( ! $instance ) {
 		return false;
 	}


### PR DESCRIPTION
Hi there,

An error occurring when called `gianism_is_user_connected_with`, so I fixed it.
I'd be grateful if you would merge.

error message:
> Fatal Error (E_ERROR): Call to undefined method Gianism\Bootstrap::get_service_instance() {"code":1,"message":"Call to undefined method Gianism\\Bootstrap::get_service_instance()","file":"/var/app/current/content/plugins/gianism/functions.php","line":141} []

Many thanks,
atomita