### PR TITLE
Support array of $args['to'] in NoMailService::mail_handler

### DIFF
--- a/app/Gianism/Service/NoMailService.php
+++ b/app/Gianism/Service/NoMailService.php
@@ -72,10 +72,19 @@ abstract class NoMailService extends AbstractService {
 	 * @return array
 	 */
 	final public function mail_handler( $args ) {
-		if ( $this->is_pseudo_mail( $args['to'] ) && ( $user_id = email_exists( $args['to'] ) ) ) {
-			// Send mail
-			$this->wp_mail( $user_id, $args['subject'], $args['message'], $args['headers'], $args['attachments'] );
+		$tos = [];
+		foreach (is_array($args['to']) ? $args['to'] : [$args['to']] as $to) {
+			if ( $this->is_pseudo_mail( $to ) && ( $user_id = email_exists( $to ) ) ) {
+				// Send mail
+				$this->wp_mail( $user_id, $args['subject'], $args['message'], $args['headers'], $args['attachments'] );
+			} else {
+				$tos[] = $to;
+			}
+		}
+		if (empty($tos)) {
 			add_action( 'phpmailer_init', [ $this, 'hijack_php_mailer' ] );
+		} else {
+			$args['to'] = $tos;
 		}
 		return $args;
 	}


### PR DESCRIPTION
add_filter('wp_mail')の$args['to']が配列パターンのケースに対応しました。

https://developer.wordpress.org/reference/hooks/wp_mail/
https://developer.wordpress.org/reference/functions/wp_mail/