### PR TITLE
Change decode process

### DIFF
--- a/app/Gianism/Service/Line.php
+++ b/app/Gianism/Service/Line.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gianism\Service;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 /**
  * Line class
@@ -158,7 +159,7 @@ class Line extends NoMailService {
 			throw new \Exception( __( 'Sorry, but failed to parse request.', 'wp-gianism' ), 500 );
 		}
 		JWT::$leeway    = 5;
-		$jwt            = JWT::decode( $json->id_token, $this->line_channel_secret, [ 'HS256' ] );
+		$jwt            = JWT::decode( $json->id_token, new Key($this->line_channel_secret, 'HS256') );
 		$json->id_token = $jwt;
 		return $json;
 	}


### PR DESCRIPTION
LINEログイン時に「”kid” empty, unable to lookup connect key 」と表示されログインできない問題、解決できたのでプルリクエストさせていただきます。

php-jwtのデコードプロセスが変更されたことが原因のようです。
https://stackoverflow.com/questions/72278051/why-is-jwtdecode-returning-status-kid-empty-unable-to-lookup-corr

こちらで2サイト確認した限りでは問題なく動作していました。
よろしくお願いいたします。