### PR TITLE
Add SNS Login Block and fix PHPStan errors

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,12 +62,25 @@ npm run fix:js
 src/
   js/          # JavaScript ソース
   sass/        # SCSS ソース
+  blocks/      # Gutenberg ブロックソース
 assets/
   js/          # ビルド済み JS（gitignore）
   css/         # ビルド済み CSS（gitignore）
+  blocks/      # ビルド済みブロック（gitignore）
   vendor/      # コピーされたライブラリ（gitignore）
   fonts/       # フォント（git管理）
   img/         # 画像（git管理）
+```
+
+### ブロック開発
+
+```bash
+# 新しいブロックを作成（namespace=gianism, textdomain=wp-gianism が自動設定）
+npm run create-block -- [block-slug]
+# 例: npm run create-block -- login → src/blocks/login/ に gianism/login ブロックを作成
+
+# ブロックのビルド
+npm run build:blocks
 ```
 
 ## PHP

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,117 @@
+# Gianism プラグイン開発ガイド
+
+## 概要
+
+GianismはWordPressをSNS（Google, Facebook, X/Twitter, LINE等）と連携させるプラグインです。
+利用方法はREADME.mdをみてください。
+
+## ローカル環境
+
+Local by Flywheelで管理しています。URLは `https://local.gianism.info` です。
+管理者でのログイン情報は `admin/password` です。
+Chrome MCPサーバーなどを使って、アクセスすることができます。
+CLI操作は以下を参照してください。
+
+```
+~/bin/local-wp gianism-local -- [ここでwp-cliコマンド]
+```
+
+NOTE: このローカル情報はDockerにおきかえ予定です。
+
+## ビルドシステム
+
+Node.js 22以上が必要です（voltaで管理）。
+
+### コマンド
+
+```bash
+# 依存関係インストール
+npm install
+
+# 本番ビルド（CSS, JS, 依存関係ダンプ）
+npm run package
+
+# ファイル監視（開発時）
+npm run watch
+
+# 個別ビルド
+npm run build:css   # SCSS → CSS
+npm run build:js    # JS バンドル
+npm run dump        # wp-dependencies.json 生成
+
+# Lint
+npm run lint        # CSS と JS 両方
+npm run lint:css    # stylelint
+npm run lint:js     # eslint
+
+# 自動修正
+npm run fix         # CSS と JS 両方
+npm run fix:css
+npm run fix:js
+```
+
+### 使用ツール
+
+- **JS**: `@kunoichi/grab-deps` - WordPress依存関係を解析してバンドル
+- **CSS**: `sass` CLI + `postcss` with `autoprefixer`
+- **Lint**: `@wordpress/scripts` (eslint, stylelint)
+
+### ディレクトリ構造
+
+```
+src/
+  js/          # JavaScript ソース
+  sass/        # SCSS ソース
+assets/
+  js/          # ビルド済み JS（gitignore）
+  css/         # ビルド済み CSS（gitignore）
+  vendor/      # コピーされたライブラリ（gitignore）
+  fonts/       # フォント（git管理）
+  img/         # 画像（git管理）
+```
+
+## PHP
+
+### 静的解析
+
+```bash
+composer analyze   # PHPStan
+```
+
+### コーディング規約
+
+```bash
+composer lint     # チェック
+composer fix    # 自動修正
+```
+
+### クラス構造
+
+- `app/Gianism/Service/` - 各SNSサービスの実装
+- `app/Gianism/Plugins/` - 拡張プラグイン
+- `app/Gianism/Controller/` - コントローラー
+- `templates/` - テンプレートファイル
+
+## Git運用
+
+- メインブランチ: `master`
+- コミットは `git cc-commit "メッセージ"` を使用（Co-Authored-By が自動追加される）
+- プルリクエストは `gh pr create` で作成
+
+## GitHub Actions
+
+- `.github/workflows/wordpress.yml` - WordPress.org へのデプロイ（release 公開時にトリガー）
+- `.github/workflows/test.yml` - PHPUnit などの自動テスト
+- リリース時は GitHub Release を作成すると自動的に WordPress.org にデプロイされ、zip が Release に添付される
+
+## リリース手順
+
+1. `README.md` の Changelog を更新。このファイルがWordPress用の `readme.txt` に変換されます。
+2. GitHub で Release を作成（タグは `v1.2.3` 形式）
+3. GitHub Actions が自動でビルド・デプロイ
+
+## 注意事項
+
+- `assets/js/`, `assets/css/`, `assets/vendor/` はビルドで生成されるため git 管理しない
+- `assets/fonts/`, `assets/img/` は git 管理する
+- JSファイルのヘッダーコメント( `/*!` で始めること )で `@handle`, `@deps`, `@strategy` を指定すると `grab-deps` が WordPress の依存関係を自動処理する

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Here is a list of change logs.
 
 * Add workspace limited feature for Google. You can limit the user registration only from your Google Workspace.
 * Remove login button styles to follow brands' guideline.
+* Add new block **SNS Login Block**
 
 ### 5.3.0
 

--- a/app/Gianism/Bootstrap.php
+++ b/app/Gianism/Bootstrap.php
@@ -51,8 +51,9 @@ class Bootstrap extends Singleton {
 	 */
 	protected function __construct( array $argument = [] ) {
 		parent::__construct( $argument );
-		// Register assets
+		// Register assets and blocks
 		add_action( 'init', array( $this, 'register_assets' ) );
+		add_action( 'init', array( $this, 'register_blocks' ) );
 		// Admin page
 		add_action(
 			'admin_menu',
@@ -125,6 +126,25 @@ class Bootstrap extends Singleton {
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 			// Add short codes.
 			ShortCodes::get_instance();
+		}
+	}
+
+	/**
+	 * Register blocks
+	 */
+	public function register_blocks() {
+		$blocks_dir = $this->dir . '/assets/blocks';
+		if ( ! is_dir( $blocks_dir ) ) {
+			return;
+		}
+		foreach ( scandir( $blocks_dir ) as $block ) {
+			if ( '.' === $block || '..' === $block ) {
+				continue;
+			}
+			$block_json = $blocks_dir . '/' . $block . '/block.json';
+			if ( file_exists( $block_json ) ) {
+				register_block_type( $block_json );
+			}
 		}
 	}
 

--- a/app/Gianism/Controller/Rewrite.php
+++ b/app/Gianism/Controller/Rewrite.php
@@ -158,7 +158,6 @@ class Rewrite extends AbstractController {
 			$filtered_service = apply_filters( 'gianism_filter_service_prefix', $service );
 			if ( in_array( $service, $this->prefixes, true ) && ( $this->service->get( $filtered_service ) ) ) {
 				nocache_headers();
-				/** @var AbstractService $instance */
 				// Parse Request
 				$this->service->get( $filtered_service )->parse_request( $action, $wp_query );
 			} else {

--- a/app/Gianism/Plugins/Bot.php
+++ b/app/Gianism/Plugins/Bot.php
@@ -45,7 +45,9 @@ class Bot extends PluginBase {
 	 * @return bool
 	 */
 	public function plugin_enabled() {
-		return $this->service->get( 'twitter' )->tw_use_cron;
+		/** @var \Gianism\Service\Twitter $twitter */
+		$twitter = $this->service->get( 'twitter' );
+		return $twitter->tw_use_cron;
 	}
 
 

--- a/app/Gianism/Service/Facebook.php
+++ b/app/Gianism/Service/Facebook.php
@@ -653,10 +653,10 @@ class Facebook extends NoMailService {
 
 	/**
 	 * @param array{
-	 *     app_id:string,
-	 *     app_secret:string,
-	 *     default_graph_version:string,
-	 *     persistent_data_handler:\Facebook\PersistentData\PersistentDataInterface
+	 *     app_id?:string,
+	 *     app_secret?:string,
+	 *     default_graph_version?:string,
+	 *     persistent_data_handler?:\Facebook\PersistentData\PersistentDataInterface
 	 * } $config Setting for Facebook API Client
 	 *
 	 * @return \Facebook\Facebook

--- a/app/Gianism/Service/Twitter.php
+++ b/app/Gianism/Service/Twitter.php
@@ -540,6 +540,7 @@ class Twitter extends NoMailService {
 		if ( ! $media ) {
 			return new \WP_Error( 500, __( 'Failed to upload media to twitter.', 'wp-gianism' ) );
 		}
+		/** @var \stdClass $media */
 		return $media->media_id_string;
 	}
 
@@ -566,7 +567,7 @@ class Twitter extends NoMailService {
 	 *
 	 * @return object|\WP_Error Json format object.
 	 */
-	private function follow_me( TwitterOAuth $oauth = null, $screen_name = false ) {
+	private function follow_me( TwitterOAuth $oauth = null, $screen_name = '' ) {
 		return new \WP_Error( 'twitter_api_error', __( 'Follow API is deprecated.', 'wp-gianism' ) );
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,7 @@ function gianism_get_user_by_service( $service, $credential ) {
 	}
 	switch ( $service ) {
 		case 'facebook':
+			/** @var \Gianism\Service\Facebook $instance */
 			$user_id = $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value = %s", $instance->umeta_id, $credential ) );
 			if ( $user_id ) {
 				return new WP_User( $user_id );
@@ -127,7 +128,7 @@ function gianism_login( $before = '', $after = '', $redirect_to = '' ) {
  * If user is logged in, display SNS connect buttons.
  *
  * @since 4.3.4
- * @param
+ * @param \WP_User|null $user User object. Default current user.
  */
 function gianism_connection( $user = null ) {
 	if ( is_null( $user ) ) {

--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
 	"version": "5.0.0",
 	"description": "Gianism - Connect WordPress with SNS",
 	"scripts": {
-		"package": "npm run copy && npm run build:css && npm run build:js && npm run dump",
+		"package": "npm run copy && npm run build:css && npm run build:js && npm run build:blocks && npm run dump",
 		"watch": "npm-watch",
 		"copy": "mkdir -p assets/vendor && cp node_modules/js-cookie/dist/js.cookie.js node_modules/js-cookie/dist/js.cookie.min.js assets/vendor/",
 		"build:css": "sass ./src/sass/:./assets/css/ --style=compressed && postcss ./assets/css/*.css --use autoprefixer --replace",
 		"build:js": "grab-deps js src/js assets/js",
+		"build:blocks": "wp-scripts build --source-path=src/blocks --output-path=assets/blocks",
+		"create-block": "npx @wordpress/create-block --no-plugin --namespace=gianism --textdomain=wp-gianism --target-dir=src/blocks",
 		"dump": "grab-deps dump assets/js,assets/css",
 		"fix": "npm run fix:js && npm run fix:css",
-		"fix:js": "eslint --fix -c .eslintrc src/js",
-		"fix:css": "stylelint --fix src/sass",
+		"fix:js": "wp-scripts lint-js --fix './src/js/**/*.js' './src/blocks/**/*.js'",
+		"fix:css": "wp-scripts lint-style --fix './src/sass/**/*.scss' './src/blocks/**/*.scss'",
 		"lint": "npm run lint:css && npm run lint:js",
-		"lint:css": "wp-scripts lint-style './src/sass/**/*.scss'",
-		"lint:js": "wp-scripts lint-js ./src/js"
+		"lint:css": "wp-scripts lint-style './src/sass/**/*.scss' './src/blocks/**/*.scss'",
+		"lint:js": "wp-scripts lint-js './src/js/**/*.js' './src/blocks/**/*.js'"
 	},
 	"engines": {
 		"node": ">=22.0"
@@ -42,6 +44,12 @@
 			"extensions": "scss",
 			"patterns": [
 				"src/sass"
+			]
+		},
+		"build:blocks": {
+			"extensions": "js,scss,php,json",
+			"patterns": [
+				"src/blocks"
 			]
 		},
 		"dump": {

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -32,4 +32,5 @@
 	<exclude-pattern>*.css</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/wordpress/</exclude-pattern>
+	<exclude-pattern>*/assets/blocks/*</exclude-pattern>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
     paths:
         - app
         - functions
@@ -23,3 +23,13 @@ parameters:
 
     ignoreErrors:
         - '#Path in require_once\(\) "\./wp-admin/includes/upgrade\.php" is not a file or it does not exist\.#'
+        # External classes that may not be installed
+        - '#Google_Service_Plus#'
+        - '#Google_Service_Oauth2_Userinfoplus#'
+        - '#PHPMailer#'
+        - '#SimpleWpMembership#'
+        # Template files are included within class methods, so protected access is valid
+        - message: '#Access to protected property Gianism\\UI\\Screen::\$views#'
+          path: templates/parts/header.php
+        - message: '#Call to protected method is_view\(\) of class Gianism\\UI\\Screen#'
+          path: templates/parts/header.php

--- a/src/blocks/login/block.json
+++ b/src/blocks/login/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "gianism/login",
+	"version": "0.1.0",
+	"title": "SNS Login Buttons",
+	"category": "widgets",
+	"icon": "admin-users",
+	"description": "Display SNS login buttons for Gianism.",
+	"example": {},
+	"attributes": {
+		"redirectTo": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": true
+	},
+	"textdomain": "wp-gianism",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": [ "file:./style-index.css", "gianism" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/login/edit.js
+++ b/src/blocks/login/edit.js
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import './editor.scss';
+
+export default function Edit( { attributes, setAttributes } ) {
+	const { redirectTo } = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wp-gianism' ) }>
+					<TextControl
+						label={ __( 'Redirect URL', 'wp-gianism' ) }
+						help={ __( 'URL to redirect after login. Leave empty for current page.', 'wp-gianism' ) }
+						value={ redirectTo }
+						onChange={ ( value ) => setAttributes( { redirectTo: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...useBlockProps() }>
+				<ServerSideRender
+					block="gianism/login"
+					attributes={ attributes }
+				/>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/login/editor.scss
+++ b/src/blocks/login/editor.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor-only styles for gianism/login block.
+ */
+.wp-block-gianism-login a {
+	// Prevent link clicks in the editor.
+	pointer-events: none;
+}

--- a/src/blocks/login/index.js
+++ b/src/blocks/login/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+import './style.scss';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/src/blocks/login/render.php
+++ b/src/blocks/login/render.php
@@ -8,7 +8,7 @@
  * @var WP_Block $block      Block instance.
  */
 
-$redirect_to = $attributes['redirectTo'] ?? '';
+$redirect_to        = $attributes['redirectTo'] ?? '';
 $wrapper_attributes = get_block_wrapper_attributes();
 ?>
 <div <?php echo $wrapper_attributes; ?>>

--- a/src/blocks/login/render.php
+++ b/src/blocks/login/render.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Server-side rendering of the `gianism/login` block.
+ *
+ * @package Gianism
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+$redirect_to = $attributes['redirectTo'] ?? '';
+$wrapper_attributes = get_block_wrapper_attributes();
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<?php gianism_login( '', '', $redirect_to ); ?>
+</div>

--- a/src/blocks/login/style.scss
+++ b/src/blocks/login/style.scss
@@ -1,0 +1,6 @@
+/**
+ * Frontend and editor styles for gianism/login block.
+ */
+.wp-block-gianism-login {
+	// Inherits existing gianism button styles.
+}

--- a/templates/parts/header.php
+++ b/templates/parts/header.php
@@ -1,10 +1,7 @@
 <?php
-/** @var $this \Gianism\UI\Screen */
+/** @var \Gianism\UI\Screen $this */
 
-defined( 'ABSPATH' ) or die();
-if ( ! isset( $this ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <div class="wrap gianism-wrap">

--- a/templates/parts/sidebar.php
+++ b/templates/parts/sidebar.php
@@ -1,10 +1,7 @@
 <?php
-/** @var $this \Gianism\UI\Screen */
+/** @var \Gianism\UI\Screen $this */
 
-defined( 'ABSPATH' ) or die();
-if ( ! isset( $this ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 ?>
 <div class="sidebar">
 	<div id="index">

--- a/templates/setting/google.php
+++ b/templates/setting/google.php
@@ -1,10 +1,8 @@
 <?php
-defined( 'ABSPATH' ) or die();
-/** @var $this \Gianism\UI\Screen */
-/** @var $instance \Gianism\Service\Google */
-if ( ! isset( $this, $instance ) ) {
-	return;
-}
+/** @var \Gianism\UI\Screen $this */
+/** @var \Gianism\Service\Google $instance */
+
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <h3>Google</h3>

--- a/templates/setup.php
+++ b/templates/setup.php
@@ -1,10 +1,7 @@
 <?php
-/** @var $this \Gianism\UI\SettingScreen */
+/** @var \Gianism\UI\SettingScreen $this */
 
-defined( 'ABSPATH' ) or die();
-if ( ! isset( $this ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
 foreach ( $this->service->all_services() as $service ) {
 	/** @var \Gianism\Service\AbstractService $instance */


### PR DESCRIPTION
## Summary
- Add SNS Login Buttons block for site editor (#144)
- Create block build system for future block development
- Fix PHPStan errors after level increase (#134)
- Add development guide (CLAUDE.md)

## Changes

### New Block System
- Add `npm run build:blocks` and `npm run create-block` scripts
- Auto-register blocks from `assets/blocks/` directory
- Source files in `src/blocks/`, built to `assets/blocks/`

### SNS Login Block
- New Gutenberg block `gianism/login` for displaying SNS login buttons
- Server-side rendering using `gianism_login()` function
- Block attribute for redirect URL after login
- Editor preview with disabled links to prevent navigation

### PHPStan Fixes
- Fix PHPDoc format (`@var \Class $var` style)
- Add type annotations for external library instances
- Update phpstan.neon with ignoreErrors for optional external classes
- Fix array type hints in Facebook.php

## Test Plan
- [ ] Build blocks: `npm run build:blocks`
- [ ] Run lint: `composer lint`
- [ ] Run PHPStan: `composer analyze`
- [ ] Add SNS Login block in site editor
- [ ] Verify login buttons display correctly on frontend

Closes #144
Closes #134

🤖 Generated with [Claude Code](https://claude.ai/code)