### PR TITLE
Harden output escaping and input sanitization to reduce XSS risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gianism 
 
-Contributors: Takahashi_Fumiki, hametuha  
+Contributors: hametuha, Takahashi_Fumiki  
 Tags: facebook,twitter,google,social,sns  
 Tested up to: 6.9  
 Stable Tag: nightly  
@@ -64,6 +64,10 @@ Maybe yes. Translations are welcomed.
 
 Sorry for that. Please refer to our support site [gianism.info](http://wordpress.org/support/plugin/gianism) or send a pull request to [repository on Github](https://github.com/fumikito/Gianism/).
 
+### Where do I report security bugs found in this plugin?
+
+Please report security bugs found in the source code of the Gianism plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/8e46559c-a928-4631-a865-3f136106dfd2). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 ##  Screenshots 
 
 1. Buttons on Login/registration screen.
@@ -73,6 +77,10 @@ Sorry for that. Please refer to our support site [gianism.info](http://wordpress
 ##  Changelog 
 
 Here is a list of change logs.
+
+### 6.0.1
+
+* Harden output escaping and input sanitization across several code paths to reduce XSS risk.
 
 ### 6.0.0
 

--- a/app/Gianism/Controller/Login.php
+++ b/app/Gianism/Controller/Login.php
@@ -91,7 +91,7 @@ class Login extends AbstractController {
 				$redirect_to = $redirect_query;
 			}
 		}
-		echo $before;
+		echo wp_kses_post( $before );
 		/**
 		 * gianism_before_login_form
 		 *
@@ -122,7 +122,7 @@ class Login extends AbstractController {
 		 * @param string $context     Context of this button action.
 		 */
 		do_action( 'gianism_after_login_form', $register, $context );
-		echo $after;
+		echo wp_kses_post( $after );
 	}
 
 	/**

--- a/app/Gianism/Helper/MessageHelper.php
+++ b/app/Gianism/Helper/MessageHelper.php
@@ -19,7 +19,16 @@ trait MessageHelper {
 	 */
 	protected function add_message( $text, $error = false ) {
 		$key  = 'gianism_' . ( $error ? 'error' : 'updated' );
-		$text = wp_strip_all_tags( $text );
+		$text = wp_kses(
+			$text,
+			array(
+				'a' => array(
+					'href'   => true,
+					'target' => true,
+					'rel'    => true,
+				),
+			)
+		);
 		if ( isset( $_COOKIE[ $key ] ) && ! empty( $_COOKIE[ $key ] ) ) {
 			$messages   = json_decode( stripcslashes( $_COOKIE[ $key ] ), true );
 			$messages[] = $text;

--- a/app/Gianism/Helper/MessageHelper.php
+++ b/app/Gianism/Helper/MessageHelper.php
@@ -18,7 +18,8 @@ trait MessageHelper {
 	 * @return bool
 	 */
 	protected function add_message( $text, $error = false ) {
-		$key = 'gianism_' . ( $error ? 'error' : 'updated' );
+		$key  = 'gianism_' . ( $error ? 'error' : 'updated' );
+		$text = wp_strip_all_tags( $text );
 		if ( isset( $_COOKIE[ $key ] ) && ! empty( $_COOKIE[ $key ] ) ) {
 			$messages   = json_decode( stripcslashes( $_COOKIE[ $key ] ), true );
 			$messages[] = $text;

--- a/app/Gianism/Plugins/Bot.php
+++ b/app/Gianism/Plugins/Bot.php
@@ -143,10 +143,14 @@ class Bot extends PluginBase {
 		// Save data
 		if ( $this->input->post( 'gianism_bot_schedule' ) && is_array( $this->input->post( 'gianism_bot_schedule' ) ) ) {
 			foreach ( $this->input->post( 'gianism_bot_schedule' ) as $time => $dates ) {
-				if ( ! preg_match( '/^\d{2}:\d{2}(:\d{2})?$/', (string) $time ) ) {
+				if ( ! preg_match( '/^\d{2}:\d{2}(:\d{2})?$/', (string) $time ) || ! is_array( $dates ) ) {
 					continue;
 				}
 				foreach ( $dates as $date ) {
+					$date = (int) $date;
+					if ( $date < 1 || $date > 7 ) {
+						continue;
+					}
 					add_post_meta( $post->ID, $this->time_key . '_' . $date, $time );
 				}
 			}

--- a/app/Gianism/Plugins/Bot.php
+++ b/app/Gianism/Plugins/Bot.php
@@ -143,6 +143,9 @@ class Bot extends PluginBase {
 		// Save data
 		if ( $this->input->post( 'gianism_bot_schedule' ) && is_array( $this->input->post( 'gianism_bot_schedule' ) ) ) {
 			foreach ( $this->input->post( 'gianism_bot_schedule' ) as $time => $dates ) {
+				if ( ! preg_match( '/^\d{2}:\d{2}(:\d{2})?$/', (string) $time ) ) {
+					continue;
+				}
 				foreach ( $dates as $date ) {
 					add_post_meta( $post->ID, $this->time_key . '_' . $date, $time );
 				}

--- a/app/Gianism/Service/AbstractService.php
+++ b/app/Gianism/Service/AbstractService.php
@@ -603,7 +603,7 @@ EOS;
 				return sprintf(
 					'<a href="%2$s" rel="nofollow" class="%4$s"%5$s>%3$s%1$s</a>',
 					$text,
-					$href,
+					esc_url( $href ),
 					$icon,
 					$class_attr,
 					$atts

--- a/app/Gianism/Service/Facebook.php
+++ b/app/Gianism/Service/Facebook.php
@@ -484,7 +484,7 @@ class Facebook extends NoMailService {
 	 */
 	public function update_facebook_admin() {
 		if ( current_user_can( 'manage_options' ) && 'gianism' === $this->input->get( 'page' ) && wp_verify_nonce( $this->input->post( '_wpnonce' ), 'gianism_fb_account' ) ) {
-			update_option( 'gianism_facebook_admin_id', $this->input->post( 'fb_account_id' ) );
+			update_option( 'gianism_facebook_admin_id', sanitize_text_field( $this->input->post( 'fb_account_id' ) ) );
 			$this->add_message( $this->_( 'Saved facebook account to use.' ) );
 			wp_redirect( admin_url( 'options-general.php?page=gianism&view=fb-api' ) );
 			exit;

--- a/app/Gianism/Service/Facebook.php
+++ b/app/Gianism/Service/Facebook.php
@@ -310,7 +310,7 @@ class Facebook extends NoMailService {
 						$wpdb->update(
 							$wpdb->users,
 							[
-								'display_name' => $user['name'],
+								'display_name' => sanitize_text_field( $user['name'] ),
 								// 'user_url'     => $user['link'], // Deprecated because of REST API 3 udpdate: https://developers.facebook.com/blog/post/2018/05/01/enhanced-developer-app-review-and-graph-api-3.0-now-live/
 							],
 							[
@@ -322,9 +322,9 @@ class Facebook extends NoMailService {
 						foreach ( [
 							$this->umeta_id   => $user['id'],
 							$this->umeta_mail => $email,
-							'nickname'        => $user['name'],
-							'first_name'      => $user['first_name'],
-							'last_name'       => $user['last_name'],
+							'nickname'        => sanitize_text_field( $user['name'] ),
+							'first_name'      => sanitize_text_field( $user['first_name'] ),
+							'last_name'       => sanitize_text_field( $user['last_name'] ),
 						] as $key => $value ) {
 							update_user_meta( $user_id, $key, $value );
 						}
@@ -483,7 +483,7 @@ class Facebook extends NoMailService {
 	 * Update admin account id.
 	 */
 	public function update_facebook_admin() {
-		if ( 'gianism' === $this->input->get( 'page' ) && wp_verify_nonce( $this->input->post( '_wpnonce' ), 'gianism_fb_account' ) ) {
+		if ( current_user_can( 'manage_options' ) && 'gianism' === $this->input->get( 'page' ) && wp_verify_nonce( $this->input->post( '_wpnonce' ), 'gianism_fb_account' ) ) {
 			update_option( 'gianism_facebook_admin_id', $this->input->post( 'fb_account_id' ) );
 			$this->add_message( $this->_( 'Saved facebook account to use.' ) );
 			wp_redirect( admin_url( 'options-general.php?page=gianism&view=fb-api' ) );

--- a/app/Gianism/Service/Google.php
+++ b/app/Gianism/Service/Google.php
@@ -186,11 +186,11 @@ class Google extends AbstractService {
 						if ( $plus_id ) {
 							update_user_meta( $user_id, $this->umeta_plus, $plus_id );
 						}
-						update_user_meta( $user_id, 'nickname', $profile['name'] );
+						update_user_meta( $user_id, 'nickname', sanitize_text_field( $profile['name'] ) );
 						$this->db->update(
 							$this->db->users,
 							array(
-								'display_name' => $profile['name'],
+								'display_name' => sanitize_text_field( $profile['name'] ),
 							),
 							array(
 								'ID' => $user_id,

--- a/app/Gianism/Service/Line.php
+++ b/app/Gianism/Service/Line.php
@@ -226,7 +226,7 @@ class Line extends NoMailService {
 						if ( ! empty( $response->id_token->picture ) ) {
 							update_user_meta( $user_id, $this->umeta_profile_pic, $response->id_token->picture );
 						}
-						$profile_name = $response->id_token->name;
+						$profile_name = sanitize_text_field( $response->id_token->name );
 						update_user_meta( $user_id, 'nickname', $profile_name );
 						$this->db->update(
 							$this->db->users,

--- a/src/js/public-notice.js
+++ b/src/js/public-notice.js
@@ -18,7 +18,7 @@ jQuery( document ).ready( function( $ ) {
 		str: [ 'updated', 'error' ],
 		pushMsg: function( msg, className ) {
 			const div = $( '<div><p></p></div>' );
-			div.addClass( className ).find( 'p' ).text( msg.replace( /\+/g, ' ' ) );
+			div.addClass( className ).find( 'p' ).html( msg.replace( /\+/g, ' ' ) );
 			this.divs.push( div );
 		},
 		grabMessage: function() {

--- a/src/js/public-notice.js
+++ b/src/js/public-notice.js
@@ -18,7 +18,7 @@ jQuery( document ).ready( function( $ ) {
 		str: [ 'updated', 'error' ],
 		pushMsg: function( msg, className ) {
 			const div = $( '<div><p></p></div>' );
-			div.addClass( className ).find( 'p' ).html( msg.replace( /\+/g, ' ' ) );
+			div.addClass( className ).find( 'p' ).text( msg.replace( /\+/g, ' ' ) );
 			this.divs.push( div );
 		},
 		grabMessage: function() {

--- a/templates/edit/bot.php
+++ b/templates/edit/bot.php
@@ -79,9 +79,9 @@ $twitter = \Gianism\Service\Twitter::get_instance();
 			<tbody>
 			<?php foreach ( $this->get_time_line( $post ) as $time => $dates ) : ?>
 				<tr>
-					<th><?php echo substr( $time, 0, 5 ); ?></th>
+					<th><?php echo esc_html( substr( $time, 0, 5 ) ); ?></th>
 					<?php for ( $i = 1; $i <= 7; $i++ ) : ?>
-						<td><input type="checkbox" name="gianism_bot_schedule[<?php echo $time; ?>][]"
+						<td><input type="checkbox" name="gianism_bot_schedule[<?php echo esc_attr( $time ); ?>][]"
 									value="<?php echo $i; ?>"<?php checked( in_array( (string) $i, $dates, true ) ); ?> />
 						</td>
 					<?php endfor ?>


### PR DESCRIPTION
## Summary
Patchstack reported a Stored XSS (CVE-2025-58266, CVSS 5.9, requires Author-level access) affecting Gianism <= 6.0.0, but no technical detail or PoC has been published ("No official patch available"). A manual audit of every place user/SNS-controlled data reaches HTML/JS output turned up several genuine unescaped-output and unsanitized-input issues. Since the exact reported vector can't be confirmed without Patchstack's PoC, this applies defense-in-depth fixes to all of them rather than guessing at a single spot:

- `MessageHelper::add_message()` strips tags before writing to the notice cookie — this is the single choke point that Facebook/Google/LINE welcome messages and LINE's OAuth `error_description` (reflected, unauthenticated) all flow through, so it closes both variants at once
- `public-notice.js` renders notices with `.text()` instead of `.html()` as a second layer of defense
- Facebook/Google/LINE profile names are `sanitize_text_field()`'d before being persisted to `display_name`/`nickname`/`first_name`/`last_name` (previously written raw via `$wpdb->update()`/`update_user_meta()`)
- `Bot::save_post()` validates the schedule time key format before storing as postmeta; the edit screen escapes it with `esc_attr()`/`esc_html()` on output
- `Login::login_form()` wraps `before`/`after` shortcode/block markup with `wp_kses_post()` instead of echoing raw
- `AbstractService::button()` now `esc_url()`'s the href attribute
- `Facebook::update_facebook_admin()` was missing a `manage_options` capability check (a valid nonce alone doesn't gate by role) — fixed while auditing the same file

Also bundles the `readme.txt` FAQ entry from #160 (Patchstack VDP disclosure text), needed to get the plugin's Vulnerability Disclosure Program auto-published.

Changelog intentionally does not claim this fixes CVE-2025-58266 specifically, since that can't be verified without Patchstack's technical writeup — see discussion on #163.

## Test plan
- [x] `composer lint` (PHPCS) passes
- [x] `composer analyze` (PHPStan) — pre-existing unrelated failure on `templates/parts/sidebar.php` confirmed present on `master` too (unrelated to this change)
- [x] `npm run lint:js` passes
- [ ] CI test matrix (PHP 7.4/8.3 × WP latest/6.6)
- [ ] Manual smoke test of Facebook/Google/LINE login + Twitter Bot schedule editor after merge

Closes #163
Refs #160