### PR TITLE
Fix Xserver staging deploy build failure

### DIFF
--- a/.github/workflows/xserver.yml
+++ b/.github/workflows/xserver.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Deploy Staging
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
           node-version: '22'
 
       - name: Build Plugin
-        run: bash bin/build.sh refs/tags/v${{ github.sha }}
+        run: bash bin/build.sh ${{ github.sha }}
 
       - name: Deploy with Rsync
         uses: Pendect/action-rsyncer@v1.1.0

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -18,5 +18,5 @@ echo 'Generate readme.'
 curl -L https://raw.githubusercontent.com/fumikito/wp-readme/master/wp-readme.php | php
 
 # Change version string.
-sed -i.bak "s/ \* Version: .*/ * Version: ${VERSION}/g" ./wp-gianism.php
-sed -i.bak "s/^Stable Tag: .*/Stable Tag: ${VERSION}/g" ./readme.txt
+sed -i.bak "s| \* Version: .*| * Version: ${VERSION}|g" ./wp-gianism.php
+sed -i.bak "s|^Stable Tag: .*|Stable Tag: ${VERSION}|g" ./readme.txt


### PR DESCRIPTION
## Summary
Staging deploys to Xserver have been failing since `cd869eb` changed `bin/build.sh`'s `PREFIX` from `refs/tags/v` to `v` (to match `wordpress.yml`'s `github.event.release.tag_name`, e.g. `v6.0.1`). That silently broke `xserver.yml`, which still calls `bash bin/build.sh refs/tags/v${{ github.sha }}` — since the string starts with `r` not `v`, the prefix strip is a no-op, `$VERSION` keeps its slashes, and the `/`-delimited `sed` substitution dies with `sed: unknown option to `s'`.

- `xserver.yml` now passes the plain commit SHA (no prefix, no slashes)
- Restored `bin/build.sh`'s `sed` delimiter to `|` — this was already fixed once in `d8224d5` on `feature/login-block`, but that fix never made it into `master` (looks like it was dropped somewhere in the PR #159 merge)

## Test plan
- [x] Verified the corrected `sed` line locally against a 40-char SHA-like string with no error
- [ ] Confirm the `Deploy to Xserver` workflow succeeds on the next push to `master` after this merges

Ref: https://github.com/hametuha/gianism/actions/runs/28567654268/job/84698220406